### PR TITLE
Alarm responder and lifecycle events

### DIFF
--- a/TradingAlarm.xcodeproj/project.pbxproj
+++ b/TradingAlarm.xcodeproj/project.pbxproj
@@ -9,6 +9,12 @@
 /* Begin PBXBuildFile section */
 		9B1C45702ABDD66700DFE452 /* AlarmSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1C456F2ABDD66700DFE452 /* AlarmSettingsViewController.swift */; };
 		9B1C45732ABDD6BF00DFE452 /* AlarmSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B1C45722ABDD6BF00DFE452 /* AlarmSettingsViewModel.swift */; };
+		9B2031CB2ACF7B960074C962 /* AppServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2031CA2ACF7B960074C962 /* AppServices.swift */; };
+		9B2031CD2ACF7CC80074C962 /* AtomicDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2031CC2ACF7CC80074C962 /* AtomicDictionary.swift */; };
+		9B2031CF2ACF8B450074C962 /* Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2031CE2ACF8B440074C962 /* Injection.swift */; };
+		9B2031D42AD05E240074C962 /* AppLifecycleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2031D22AD05E240074C962 /* AppLifecycleManager.swift */; };
+		9B2031D62AD19C780074C962 /* DataManager+debugJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2031D52AD19C780074C962 /* DataManager+debugJSON.swift */; };
+		9B2031D82AD19DB80074C962 /* AlarmResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2031D72AD19DB80074C962 /* AlarmResponder.swift */; };
 		9B4C921C2ACCA55700E08231 /* TimeIntervalExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4C921B2ACCA55700E08231 /* TimeIntervalExtensions.swift */; };
 		9B5ECB392AC460910088E931 /* JSONDateAndTimeConversionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5ECB382AC460910088E931 /* JSONDateAndTimeConversionsTests.swift */; };
 		9B5ECB3B2AC6E60F0088E931 /* DatesAndTimeConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5ECB3A2AC6E60F0088E931 /* DatesAndTimeConversionTests.swift */; };
@@ -48,6 +54,12 @@
 		9B1C456F2ABDD66700DFE452 /* AlarmSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingsViewController.swift; sourceTree = "<group>"; };
 		9B1C45722ABDD6BF00DFE452 /* AlarmSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingsViewModel.swift; sourceTree = "<group>"; };
 		9B2031C82ACED2060074C962 /* TradingAlarm.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TradingAlarm.entitlements; sourceTree = "<group>"; };
+		9B2031CA2ACF7B960074C962 /* AppServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServices.swift; sourceTree = "<group>"; };
+		9B2031CC2ACF7CC80074C962 /* AtomicDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicDictionary.swift; sourceTree = "<group>"; };
+		9B2031CE2ACF8B440074C962 /* Injection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Injection.swift; sourceTree = "<group>"; };
+		9B2031D22AD05E240074C962 /* AppLifecycleManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppLifecycleManager.swift; sourceTree = "<group>"; };
+		9B2031D52AD19C780074C962 /* DataManager+debugJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+debugJSON.swift"; sourceTree = "<group>"; };
+		9B2031D72AD19DB80074C962 /* AlarmResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmResponder.swift; sourceTree = "<group>"; };
 		9B4C921B2ACCA55700E08231 /* TimeIntervalExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIntervalExtensions.swift; sourceTree = "<group>"; };
 		9B5ECB372AC45D250088E931 /* defaultNYAlarms.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = defaultNYAlarms.json; sourceTree = "<group>"; };
 		9B5ECB382AC460910088E931 /* JSONDateAndTimeConversionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDateAndTimeConversionsTests.swift; sourceTree = "<group>"; };
@@ -211,15 +223,21 @@
 			isa = PBXGroup;
 			children = (
 				9B2031C82ACED2060074C962 /* TradingAlarm.entitlements */,
-				9BFFD9922A7E9838004C864F /* Main.storyboard */,
-				9B5ECB422ACB9B260088E931 /* AlarmScheduler.swift */,
-				9BDD1BC62A86CE4600A34EFE /* DataManager.swift */,
 				9BDD1BBC2A84451B00A34EFE /* Data */,
 				9B1C456C2ABDD61A00DFE452 /* Sections - ViewControllers */,
 				9BD013EA2A893CC700C35373 /* Extensions */,
-				9BDD1BB52A82E90900A34EFE /* SoundPlayer.swift */,
 				9BDD1BB92A82F58400A34EFE /* Sounds */,
 				9BE118612A8124FD0007D893 /* SupportingFiles */,
+				9BFFD9922A7E9838004C864F /* Main.storyboard */,
+				9B2031CA2ACF7B960074C962 /* AppServices.swift */,
+				9B2031D22AD05E240074C962 /* AppLifecycleManager.swift */,
+				9B5ECB422ACB9B260088E931 /* AlarmScheduler.swift */,
+				9B2031D72AD19DB80074C962 /* AlarmResponder.swift */,
+				9BDD1BC62A86CE4600A34EFE /* DataManager.swift */,
+				9B2031D52AD19C780074C962 /* DataManager+debugJSON.swift */,
+				9BDD1BB52A82E90900A34EFE /* SoundPlayer.swift */,
+				9B2031CE2ACF8B440074C962 /* Injection.swift */,
+				9B2031CC2ACF7CC80074C962 /* AtomicDictionary.swift */,
 				9B5ECB3D2AC83D4B0088E931 /* TimeProvider.swift */,
 			);
 			path = TradingAlarm;
@@ -341,18 +359,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BD013EC2A893D1000C35373 /* DateExtensions.swift in Sources */,
+				9B2031CB2ACF7B960074C962 /* AppServices.swift in Sources */,
 				9BDD1BB62A82E90900A34EFE /* SoundPlayer.swift in Sources */,
+				9B2031D62AD19C780074C962 /* DataManager+debugJSON.swift in Sources */,
 				9B9930362ABE229000B7665F /* AlarmSettingTableViewCell.swift in Sources */,
 				9BDD1BC72A86CE4600A34EFE /* DataManager.swift in Sources */,
+				9B2031CD2ACF7CC80074C962 /* AtomicDictionary.swift in Sources */,
 				9BFFD9912A7E9838004C864F /* AlarmsViewController.swift in Sources */,
 				9B1C45732ABDD6BF00DFE452 /* AlarmSettingsViewModel.swift in Sources */,
 				9BFFD98D2A7E9838004C864F /* AppDelegate.swift in Sources */,
 				9BFFD98F2A7E9838004C864F /* SceneDelegate.swift in Sources */,
 				9B1C45702ABDD66700DFE452 /* AlarmSettingsViewController.swift in Sources */,
+				9B2031D42AD05E240074C962 /* AppLifecycleManager.swift in Sources */,
 				9BD014142A8FB4AE00C35373 /* StringExtensions.swift in Sources */,
 				9BDD1BBE2A84453800A34EFE /* Alarm.swift in Sources */,
 				9B4C921C2ACCA55700E08231 /* TimeIntervalExtensions.swift in Sources */,
 				9BDD1BC52A8598EA00A34EFE /* TimeString.swift in Sources */,
+				9B2031CF2ACF8B450074C962 /* Injection.swift in Sources */,
+				9B2031D82AD19DB80074C962 /* AlarmResponder.swift in Sources */,
 				9B5ECB3E2AC83D4B0088E931 /* TimeProvider.swift in Sources */,
 				9B5ECB432ACB9B260088E931 /* AlarmScheduler.swift in Sources */,
 			);

--- a/TradingAlarm/AlarmResponder.swift
+++ b/TradingAlarm/AlarmResponder.swift
@@ -1,0 +1,39 @@
+//
+//  AlarmResponder.swift
+//  TradingAlarm
+//
+//  Created by John Ingato on 10/7/23.
+//
+
+import UIKit
+import Combine
+
+
+class AlarmResponder: NSObject, UNUserNotificationCenterDelegate {
+    
+    // Publishes to subscribers when an alert becomes active
+    var triggeredAlertPublisher = PassthroughSubject<AlarmingState, Never>()
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        if let uuid = response.notification.request.content.userInfo["identifier"] as? String {
+            print("AlarmScheduler : userNotificationCenter didReceive alerId: \(uuid)")
+            
+            let alarmingState = AlarmingState(id: uuid, animated: false, sounding: false)
+            triggeredAlertPublisher.send(alarmingState)
+        }
+    }
+    
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        if let uuid = notification.request.content.userInfo["identifier"] as? String {
+            print("AlarmScheduler : userNotificationCenter willPresent alerId: \(uuid)")
+            
+            let alarmingState = AlarmingState(id: uuid, animated: true, sounding: true)
+            triggeredAlertPublisher.send(alarmingState)
+        }
+    }
+    
+    func showAlarmOnForegroundingWithoutSelectingNotification(alarm: Alarm) {
+        let alarmingState = AlarmingState(id: alarm.alarmId, animated: true, sounding: true)
+        triggeredAlertPublisher.send(alarmingState)
+    }
+}

--- a/TradingAlarm/AppLifecycleManager.swift
+++ b/TradingAlarm/AppLifecycleManager.swift
@@ -1,0 +1,188 @@
+//
+//  AppLifecycleManager.swift
+//  CgmKit
+//
+//  Created by Daniel Flynn on 11/12/20.
+//  Copyright © 2020 Dexcom. All rights reserved.
+//
+
+import Foundation
+import Combine
+import UIKit
+
+/**
+ The subset of application lifecycle events to which a CGM application might care to respond.
+ Case names mirror the event names reported to an AppDelegate or published via NotificationCenter.
+ */
+@frozen
+enum AppLifecycleEvent {
+    /// A passthrough for UIApplication.ApplicationDidBecomeActive
+    case applicationDidBecomeActive
+
+    /// A passthrough for UIApplication.ApplicationWillEnterForeground
+    case applicationWillEnterForeground
+
+    /// A passthrough for UIApplication.ApplicationWillResignActive
+    case applicationWillResignActive
+
+    /// A passthrough for UIApplication.ApplicationDidEnterBackground
+    case applicationDidEnterBackground
+
+    /// A passthrough for UIApplication.ApplicationWillTerminate
+    case applicationWillTerminate
+
+    /// Published when a CBCentralManager moves an app from suspended to running in the background.
+    case applicationWillRestoreFromBluetooth
+}
+
+/// A test-friendly substitute for UIApplication.shared.applicationState that can also be accessed on a background thread.
+@frozen
+enum AppForegroundStatus {
+    /// The app is in the foreground
+    case foreground
+
+    /// The app is in the foreground but is inactive
+    case foregroundInactive
+
+    /// The app is in the background
+    case background
+}
+
+/**
+ This protocol provides a Combine publisher version of application life cycle notifications and centralizes background task management.
+ */
+protocol AppLifecycleManagerProtocol: Injectable {
+    /// Provides a simplified method for subscribing to lifecycle notifications.
+    var appLifecycleEvent: AnyPublisher<AppLifecycleEvent, Never> { get }
+}
+
+/**
+ Monitors a subset of application lifecycle events and reduces them to a simple Combine publisher.
+ */
+final class AppLifecycleManager: InjectableContainer, AppLifecycleManagerProtocol {
+    /// Stores the notification observers.
+    private var observers = [AnyObject]()
+    
+    
+    /// Provides a simplified method for subscribing to lifecycle notifications.
+    @PassThroughPublisher var appLifecycleEventSubject: PassThroughPublisher<AppLifecycleEvent, AppLifecycleManagerProtocol>
+    
+    
+    /// Provides a simplified method for subscribing to lifecycle notifications.
+    var appLifecycleEvent: AnyPublisher<AppLifecycleEvent, Never> {
+        $appLifecycleEventSubject
+    }
+    
+    func sendAppLifecycleEvent(_ appLifecycleEvent: AppLifecycleEvent) {
+        appLifecycleEventSubject.send(appLifecycleEvent)
+    }
+    
+    /// Keeps track of the current foregrounded state of the application.
+    var appForegroundStatus: AppForegroundStatus = .background
+    
+    override init() {
+        super.init()
+        observers.append(NotificationCenter.default.addObserver(
+            forName: Notification.ApplicationDidBecomeActive,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            guard let self else { return }
+            
+            self.appForegroundStatus = .foreground
+            self.appLifecycleEventSubject.send(.applicationDidBecomeActive)
+        })
+        
+        observers.append(NotificationCenter.default.addObserver(
+            forName: Notification.ApplicationWillEnterForeground,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            guard let self else { return }
+            
+            self.appLifecycleEventSubject.send(.applicationWillEnterForeground)
+        })
+        
+        observers.append(NotificationCenter.default.addObserver(
+            forName: Notification.ApplicationWillResignActive,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            guard let self else { return }
+            
+            self.appForegroundStatus = .foregroundInactive
+            self.appLifecycleEventSubject.send(.applicationWillResignActive)
+        })
+        
+        observers.append(NotificationCenter.default.addObserver(
+            forName: Notification.ApplicationDidEnterBackground,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            guard let self else { return }
+            
+            self.appForegroundStatus = .background
+            self.appLifecycleEventSubject.send(.applicationDidEnterBackground)
+        })
+        
+        observers.append(NotificationCenter.default.addObserver(
+            forName: Notification.ApplicationWillTerminate,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            guard let self else { return }
+            
+            self.appLifecycleEventSubject.send(.applicationWillTerminate)
+        })
+    }
+}
+
+    
+
+// MARK: - Utility Extensions
+extension AppLifecycleManager {
+    private struct Notification {
+        #if os(iOS)
+        static let ApplicationDidBecomeActive = UIApplication.didBecomeActiveNotification
+        static let ApplicationWillEnterForeground = UIApplication.willEnterForegroundNotification
+        static let ApplicationWillResignActive = UIApplication.willResignActiveNotification
+        static let ApplicationDidEnterBackground = UIApplication.didEnterBackgroundNotification
+        static let ApplicationWillTerminate = UIApplication.willTerminateNotification
+        #elseif os(watchOS)
+        static let ApplicationDidBecomeActive = WKApplication.didBecomeActiveNotification
+        static let ApplicationWillEnterForeground = WKApplication.willEnterForegroundNotification
+        static let ApplicationWillResignActive = WKApplication.willResignActiveNotification
+        static let ApplicationDidEnterBackground = WKApplication.willResignActiveNotification
+        #endif
+    }
+}
+
+extension AppForegroundStatus {
+    #if os(iOS)
+    init(_ state: UIApplication.State) {
+        switch state {
+        case .active:
+            self = .foreground
+        case .inactive:
+            self = .foregroundInactive
+        case .background:
+            self = .background
+        default:
+            self = .background
+        }
+    }
+    #elseif os(watchOS)
+    init(_ state: WKApplicationState) {
+        switch state {
+        case .active:
+            self = .foreground
+        case .inactive:
+            self = .foregroundInactive
+        case .background:
+            self = .background
+        default:
+            self = .background
+        }
+    }
+    #endif
+}

--- a/TradingAlarm/AppServices.swift
+++ b/TradingAlarm/AppServices.swift
@@ -1,0 +1,44 @@
+//
+//  AppServices.swift
+//  TradingAlarm
+//
+//  Created by John Ingato on 10/5/23.
+//
+
+import Foundation
+import Combine
+
+class AppServices {
+    
+    static var datamode: DataMode = .debugMultipleRelativeTimesToNow
+    
+    var subscriber = Set<AnyCancellable>()
+    init() {
+        // Alarmscheduler must be first because DataManager depends on it for initialization
+        InjectedValues[AlarmScheduler.self] = AlarmScheduler()
+        
+        InjectedValues[DataManager.self] =  DataManager(
+            mode: AppServices.datamode
+        )
+        
+        InjectedValues[AppLifecycleManager.self] = AppLifecycleManager()
+        
+        @Injected var appLifecycleManager: AppLifecycleManager
+        @Injected var dataManager: DataManager
+        @Injected var alarmScheduler: AlarmScheduler
+        
+        appLifecycleManager.appLifecycleEvent
+            .sink { event in
+                if case .applicationWillEnterForeground = event {
+                    if let lastDeliveredAlarm = dataManager.lastDeliveredAlarm {
+                        alarmScheduler.alarmResponder.showAlarmOnForegroundingWithoutSelectingNotification(alarm: lastDeliveredAlarm)
+                    }
+                }
+                
+                if case .applicationWillTerminate = event {
+                    alarmScheduler.resetAllAlerts()
+                }
+            }
+            .store(in: &subscriber)
+    }
+}

--- a/TradingAlarm/AtomicDictionary.swift
+++ b/TradingAlarm/AtomicDictionary.swift
@@ -1,0 +1,94 @@
+//
+//  AtomicDictionary.swift
+//
+//  Created by John T Ingato on 10/5/23.
+//
+
+import Foundation
+
+public final class AtomicDictionary<Key: Hashable, Value>: CustomDebugStringConvertible {
+    private var dictionary = [Key: Value]()
+    
+    private let queue = DispatchQueue(
+        label: "AtomicDictionary.\(UUID().uuidString)",
+        qos: .default,
+        attributes: .concurrent,
+        autoreleaseFrequency: .inherit,
+        target: .global()
+    )
+    
+    public init() {}
+
+    public init(_ dictionary: [Key: Value]) {
+        self.dictionary = dictionary
+    }
+
+    public subscript(key: Key) -> Value? {
+        get {
+            queue.sync {
+                dictionary[key]
+            }
+        }
+        set {
+            queue.sync(flags: .barrier) {
+                dictionary[key] = newValue
+            }
+        }
+    }
+    
+    public var values: Dictionary<Key, Value>.Values {
+        queue.sync {
+            dictionary.values
+        }
+    }
+    
+    public var keys: Dictionary<Key, Value>.Keys {
+        queue.sync {
+            dictionary.keys
+        }
+    }
+
+    /// Adopted from Dictionary.merge(_ other:).
+    ///
+    /// This is a simplified version that only takes the first
+    /// value in the case of any duplicates
+    public func merge(_ other: [Key: Value]) {
+        queue.sync(flags: .barrier) {
+            dictionary.merge(other) { first, _ in
+                first
+            }
+        }
+    }
+
+    public var debugDescription: String {
+        queue.sync {
+            dictionary.debugDescription
+        }
+    }
+
+    @discardableResult
+    public func removeValue(forKey key: Key) -> Value? {
+        queue.sync(flags: .barrier) {
+            dictionary.removeValue(forKey: key)
+        }
+    }
+
+    public func removeAll() {
+        queue.sync(flags: .barrier) {
+            dictionary.removeAll()
+        }
+    }
+
+    public func copy() -> AtomicDictionary<Key, Value> {
+        AtomicDictionary(dictionary)
+    }
+}
+
+extension AtomicDictionary: ExpressibleByDictionaryLiteral {
+    public convenience init(dictionaryLiteral elements: (Key, Value)...) {
+        self.init()
+        elements.forEach { key, value in
+            dictionary[key] = value
+        }
+    }
+}

--- a/TradingAlarm/DataManager+debugJSON.swift
+++ b/TradingAlarm/DataManager+debugJSON.swift
@@ -1,0 +1,28 @@
+//
+//  DataManager+debugJSON.swift
+//  TradingAlarm
+//
+//  Created by John Ingato on 10/7/23.
+//
+
+import Foundation
+
+extension DataManager {
+    /// Uses a group of times relative to the run time and returns a Data object representing a returned json string
+    /// This string is parsed from its know type into codable alarms
+    var debugJson: Data? {
+        let now = Date() + TimeInterval.oneHour
+        
+        let t1 = (now + TimeInterval.minutes(1)).timeString
+        let t2 = (now + TimeInterval.minutes(2)).timeString
+        let t3 = (now + TimeInterval.minutes(3)).timeString
+        let t4 = (now + TimeInterval.minutes(4)).timeString
+        let t5 = (now + TimeInterval.minutes(5)).timeString
+        let t6 = (now + TimeInterval.minutes(6)).timeString
+        
+        let jsonString = """
+        {"alarms":[{"id":"caa0c427-aa6a-4364-88cf-50916eb2037d","title":"NYSE will be opening soon","desc":"Have a great day trading. NYSE will open in 30 minutes","time":"\(t1)"},{"id":"af1c5264-f8f9-4ea7-9e9f-fd0e607692d1","title":"NYSE is OPEN","desc":"The stock exchange is open.  If you are playing the ORB prepare to set your range as the candles close.","time":"\(t2)"},{"id":"edd7d355-c8a0-488d-ba30-4347ca782811","title":"Mid-Morning Reversal","desc":"The Mid-Morning reversal is the time when trend can change direction.  Keep a watch on your indicators or for slowing candle growth to help determine when the change is coming. If the trend does not change, it is likely that the trend will continue for a goor portion of the day.","time":"\(t3)"},{"id":"cd4fc7ae-9cc3-4582-a7e5-da62a268d4c2","title":"London Stock Exchange is Closed","desc":"Have a great day trading. NYSE will open in 30 minutes","time":"\(t4)"},{"id":"d06d4c42-d08d-4e35-9f88-ba4571aa2995","title":"Power Hour","desc":"Its the last hour of the day","time":"\(t5)"},{"id":"d06d4c42-d08d-4e35-9f88-ba4571aa2997","title":"US Stock Market is closed","desc":"The NYSE is now officially closed.  You have 15 minutes remaining to buy or sell stocks.  Option trading is not available after the official closing.","time":"\(t6)"}]}
+        """
+        return jsonString.data(using: .utf8)
+    }
+}

--- a/TradingAlarm/DataManager.swift
+++ b/TradingAlarm/DataManager.swift
@@ -21,7 +21,9 @@ class DataManager: Injectable {
     private var alarms = Alarms(alarms: []) {
         didSet {
             @Injected var alarmScheduler: AlarmScheduler
-            alarmScheduler.schedule(alarms: activeDailyAlarms)
+            if Date.now.isTradingDay && mode == .production {
+                alarmScheduler.schedule(alarms: activeDailyAlarms)
+            }
         }
     }
     

--- a/TradingAlarm/DataManager.swift
+++ b/TradingAlarm/DataManager.swift
@@ -14,22 +14,29 @@ enum DataMode {
     case debugSingle
 }
 
-class DataManager {
-    // Singleton access property
-    static var shared = DataManager()
+class DataManager: Injectable {
     
-    let alarmScheduler = AlarmScheduler()
-    
+    /// A flag that determines which set of default alarms to use
     var mode: DataMode
     private var alarms = Alarms(alarms: []) {
         didSet {
+            @Injected var alarmScheduler: AlarmScheduler
             alarmScheduler.schedule(alarms: activeDailyAlarms)
         }
     }
     
+    /// Return an array of all Alarms regardless of thier status or grouping
+    var allAlarms: [Alarm] {
+        alarms.alarms
+    }
+    
     /// Return an array of Alarms within the current day, but where the alarmTime times have already past
     var inactiveDailyAlarms: [Alarm] {
-         enabledAlarms.filter { $0.alarmTime < Date.now }
+        enabledAlarms.filter { $0.alarmTime.timeIntervalSinceReferenceDate < Date.now.timeIntervalSinceReferenceDate }
+    }
+    
+    var lastDeliveredAlarm: Alarm? {
+        inactiveDailyAlarms.last
     }
     
     /// Return an array of Alarms within the current day that are schedule for the future
@@ -46,11 +53,6 @@ class DataManager {
     /// Return an array of all Alarms that have not been disabled by the user
     var enabledAlarms: [Alarm] {
         alarms.alarms.filter { $0.alarmEnabled == true }
-    }
-    
-    /// Return an array of all Alarms regardless of thier status or grouping
-    var allAlarms: [Alarm] {
-        alarms.alarms
     }
     
     func getAlertBy(id: String) -> Alarm? {
@@ -72,14 +74,13 @@ class DataManager {
     
     // Parse the received data object and decode into alarms
     private func parse(data: Data) throws  {
-            let decoded = try JSONDecoder().decode(Alarms.self, from: data)
-            // print(decoded)
-            self.alarms = decoded
-        }
+        let decoded = try JSONDecoder().decode(Alarms.self, from: data)
+        // print(decoded)
+        self.alarms = decoded
+    }
     
-    private init(mode: DataMode = .debugMultipleRelativeTimesToNow) {
+    func setAlarms(mode: DataMode = AppServices.datamode) {
         // Load default content based on the run mode presented from caller
-        self.mode = mode
         
         switch mode {
         case .debugMultipleRelativeTimesToNow:
@@ -111,24 +112,9 @@ class DataManager {
             }
         }
     }
-}
-
-extension DataManager {
-    /// Uses a group of times relative to the run time and returns a Data object representing a returned json string
-    /// This string is parsed from its know type into codable alarms
-    var debugJson: Data? {
-        let now = Date() + TimeInterval.oneHour
-        
-        let t1 = (now + TimeInterval.minutes(1)).timeString
-        let t2 = (now + TimeInterval.minutes(2)).timeString
-        let t3 = (now + TimeInterval.minutes(3)).timeString
-        let t4 = (now + TimeInterval.minutes(4)).timeString
-        let t5 = (now + TimeInterval.minutes(5)).timeString
-        let t6 = (now + TimeInterval.minutes(6)).timeString
-        
-        let jsonString = """
-        {"alarms":[{"id":"caa0c427-aa6a-4364-88cf-50916eb2037d","title":"NYSE will be opening soon","desc":"Have a great day trading. NYSE will open in 30 minutes","time":"\(t1)"},{"id":"af1c5264-f8f9-4ea7-9e9f-fd0e607692d1","title":"NYSE is OPEN","desc":"The stock exchange is open.  If you are playing the ORB prepare to set your range as the candles close.","time":"\(t2)"},{"id":"edd7d355-c8a0-488d-ba30-4347ca782811","title":"Mid-Morning Reversal","desc":"The Mid-Morning reversal is the time when trend can change direction.  Keep a watch on your indicators or for slowing candle growth to help determine when the change is coming. If the trend does not change, it is likely that the trend will continue for a goor portion of the day.","time":"\(t3)"},{"id":"cd4fc7ae-9cc3-4582-a7e5-da62a268d4c2","title":"London Stock Exchange is Closed","desc":"Have a great day trading. NYSE will open in 30 minutes","time":"\(t4)"},{"id":"d06d4c42-d08d-4e35-9f88-ba4571aa2995","title":"Power Hour","desc":"Its the last hour of the day","time":"\(t5)"},{"id":"d06d4c42-d08d-4e35-9f88-ba4571aa2997","title":"US Stock Market is closed","desc":"The NYSE is now officially closed.  You have 15 minutes remaining to buy or sell stocks.  Option trading is not available after the official closing.","time":"\(t6)"}]}
-        """
-        return jsonString.data(using: .utf8)
+    
+    init(mode: DataMode = AppServices.datamode) {
+        self.mode = mode
+        setAlarms(mode: mode)
     }
 }

--- a/TradingAlarm/Extensions/DateExtensions.swift
+++ b/TradingAlarm/Extensions/DateExtensions.swift
@@ -38,6 +38,10 @@ extension Date {
         
         return dateComponents
     }
+    
+    var isTradingDay: Bool {
+        !Calendar.current.isDateInWeekend(Date())
+    }
 }
 
 

--- a/TradingAlarm/Injection.swift
+++ b/TradingAlarm/Injection.swift
@@ -1,0 +1,822 @@
+//
+//  Injection.swift
+//  CgmFoundation
+//
+//  Created by Christophe Delhaze on 2/10/22.
+//  Copyright © 2022 Dexcom. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+private func key<T, PT>(_ type: T.Type, _ publisherType: PT.Type, propertyName: String) -> String {
+    "\(propertyName)-\(key(T.self))-\(key(PT.self))"
+}
+
+private func key<T>(_ type: T.Type) -> String {
+    "\(T.self)"
+}
+
+/// DO NOT ALTER,  this is used for isDebugMode as a security decoy.
+/// It's also used for asserting Injected Objects.
+public enum InjectionError: Error {
+    /// In production build, this error is triggered if an object is already injected.
+    case alreadyInjected(type: String)
+    /// Injected objects must implement the Injectable protocol
+    case classNotInjectable
+    /// Injected objects containing publishers must inherit from InjectableContainer
+    case injectableContainerRequired
+    /// Publishers inside of a class that inherit from InjectableContainer must be either a ValuePublisher or a PassThroughPublisher.
+    case wrongPublisherType
+
+    fileprivate var appId: Int {
+        switch self {
+        case .alreadyInjected:
+            return 0
+        case .classNotInjectable:
+            return 1
+        case .injectableContainerRequired:
+            return 2
+        case .wrongPublisherType:
+            return 3
+        }
+    }
+}
+
+/// Protocol to be used for every object that can be injected
+public protocol Injectable {}
+
+/// Used as a base class for injected classes that contain one or more publishers
+open class InjectableContainer: Injectable, Identifiable {
+
+    /// Required to make the init public, otherwise it's internal
+    public init() { }
+
+    /// When the injectable container is injected, all the publishers in the container must be registered.
+    public func forceRegisterValuePublishers() {
+        let mirror = Mirror(reflecting: self)
+        mirror.children.forEach { child in
+            if let childValue = child.value as? RegistrablePublisherProtocol {
+                childValue.registerPublisherAndSwitchToLatest(propertyName: child.label ?? "missingPropertyName")
+            }
+        }
+    }
+}
+
+private final class InjectionQueue {
+    let dispatchQueue: DispatchQueue = {
+        let queue = DispatchQueue(
+            label: "InjectedValues.\(UUID().uuidString)",
+            qos: .default,
+            attributes: .concurrent,
+            autoreleaseFrequency: .inherit,
+            target: .global()
+        )
+        queue.suspend()
+        return queue
+    }()
+
+    var isSuspended = true
+
+    func resume() {
+        if isSuspended {
+            dispatchQueue.resume()
+            isSuspended = false
+        }
+    }
+}
+
+/// Provides access to injected dependencies.
+public final class InjectedValues {
+    /// General dictionary for injected values
+    private static var values = AtomicDictionary<String, Any>()
+    /// Dictionary for publishers. This is separated from Values since the keys could be the same and we need to keep track of publishers separately.
+    fileprivate static var publishers = AtomicDictionary<String, Any>()
+    /// To be able to keep publishing, we need to keep track of the original publishers
+    fileprivate static var publisherSubjects = AtomicDictionary<String, Any>()
+    /// This is the constant publisher that is not affected by injection. When a subscriber sinks this publisher and a new object containing publishers is injected
+    /// the subscriptions will remain since they will be subscribed to one of the constant publishers.
+    fileprivate static var switchToLatests = AtomicDictionary<String, Any>()
+    fileprivate static var queues = AtomicDictionary<String, InjectionQueue>()
+
+    /// Value used for the isDebugMode decoy system.
+    private static let appId = Int.random(in: 1...3)
+
+    /// Returns true if any components injected starts with `Mock`
+    public static var isMocked: Bool {
+        values.keys.contains { key in
+            key.starts(with: "Mock")
+        }
+    }
+
+    /// Returns the number of components injected starting with `Mock`
+    public static var mockCount: Int {
+        values.keys.reduce(into: 0) { count, key in
+            count += key.starts(with: "Mock") ? 1 : 0
+        }
+    }
+
+    /// Internal to be used for debuging and testing...
+    static func printKeys() {
+        print("Values")
+        print(values.keys.sorted())
+        print("Publishers")
+        print(publishers.keys.sorted())
+        print("ValuePublisherSubjects")
+        print(publisherSubjects.keys.sorted())
+        print("SwitchToLatests")
+        print(switchToLatests.keys.sorted())
+        print("Queues")
+        print(queues.keys.sorted())
+    }
+
+    /** Used to detect if the app is in debug mode at runtime.
+     We want to disallow different operations in a release build and allow others in debug mode.
+     FatalError should be allowed in debug mode only to help diagnose and fix missing injections
+     Replacing an injected value is disallowed in a release build.
+    */
+    static var isDebugMode: Bool {
+        // This is used to detect if the standard error stream is a TTY, which is only the case for a debug build.
+        // This is more reliable than _isDebugAssertConfiguration() which depends on binary optimization while
+        // isatty(STDERR_FILENO) does not...`
+        // Changes in iOS or Xcode resulted in this method to only return true when connected to Xcode.
+        // To bypass this we had to add an additional way to handle setting the debug mode on from the app...
+        // To reduce likeliness of someone tampering with the DI, we are reusing an error enum.
+        // We use random int 1...3 to know which error case to inject to enable debug mode.
+
+        @InjectedOrNil var debugDetection: InjectionError?
+
+        guard let debugDetection else {
+            return isatty(STDERR_FILENO) == 1
+        }
+
+        return debugDetection.appId == appId
+    }
+
+    /// Appears to Initializes the DI Framework BUT returns an Int used to enable debug mode from the app.
+    public static func initializeFramework(appId: String) -> Int {
+        Self.appId
+    }
+
+    fileprivate static func assertInjectable<T>(_ newValue: T?) throws {
+
+        guard newValue == nil || newValue as? Injectable != nil else {
+            throw InjectionError.classNotInjectable
+        }
+
+        if let newValue = newValue as? AnyObject {
+            let isInjectableContainer = newValue as? InjectableContainer != nil
+            let mirror = Mirror(reflecting: newValue)
+            try mirror.children.forEach { child in
+                if child.value as? RegistrablePublisherProtocol != nil && !isInjectableContainer {
+                    throw InjectionError.injectableContainerRequired
+                }
+                if (String(reflecting: child.value).contains("Combine.Published")) || child.value as? any Publisher != nil {
+                    throw InjectionError.wrongPublisherType
+                }
+            }
+        }
+    }
+
+    /// A static subscript accessor for updating and references dependencies directly.
+    public static subscript<T>(type: T.Type) -> T? {
+        get {
+            if let value = values[key(T.self)] ?? values.values.first(where: { $0 as? T != nil }) {
+                return value as? T
+            }
+
+            return nil
+        }
+        set {
+            // Bypassing the auto debug mode needs to be the thing we inject
+            if newValue is InjectionError && !values.values.isEmpty { return }
+
+            if !isDebugMode {
+                guard values[key(T.self)] == nil else { return }
+            }
+
+            do {
+                try assertInjectable(newValue)
+            } catch InjectionError.classNotInjectable {
+                fatalError("Injected Objects must implement the Injectable protocol")
+            } catch InjectionError.injectableContainerRequired {
+                fatalError("Injected Objects containing a ValuePublisher or a PassThroughPublisher must inherit from InjectableContainer.")
+            } catch InjectionError.wrongPublisherType {
+                fatalError("Injected Objects containing a Publisher must inherit from InjectableContainer and must use either a ValuePublisher or a PassThroughPublisher")
+            } catch {
+                fatalError("Unexpected Injection issue")
+            }
+
+            if let injectableContainer = newValue as? InjectableContainer {
+                injectableContainer.forceRegisterValuePublishers()
+            }
+            values[key(T.self)] = newValue
+            queues[key(T.self)]?.resume()
+        }
+    }
+
+    /**
+     Insert the dependency to be injected
+        - Parameters:
+            - value: A function to create the dependency to inject
+            - type: The type of the dependency to inject
+     */
+    @discardableResult
+    public static func insert<T>(_ value: () -> T, for type: T.Type) throws -> T? {
+        if isDebugMode {
+            guard values[key(T.self)] == nil else {
+                return InjectedValues[type]
+            }
+        } else {
+            guard values[key(T.self)] == nil else {
+                throw InjectionError.alreadyInjected(type: key(T.self))
+            }
+        }
+
+        let injectedValue = value()
+
+        // Bypassing the auto debug mode needs to be the thing we inject
+        if injectedValue is InjectionError && !values.values.isEmpty { return nil}
+
+        do {
+            try assertInjectable(injectedValue)
+        } catch InjectionError.classNotInjectable {
+            fatalError("Injected Objects must implement the Injectable protocol")
+        } catch InjectionError.injectableContainerRequired {
+            fatalError("Injected Objects containing a ValuePublisher or a PassThroughPublisher must inherit from InjectableContainer.")
+        } catch InjectionError.wrongPublisherType {
+            fatalError("Injected Objects containing a Publisher must inherit from InjectableContainer and must use either a ValuePublisher or a PassThroughPublisher")
+        } catch {
+            fatalError("Unexpected Injection issue")
+        }
+
+        if let injectableContainer = injectedValue as? InjectableContainer {
+            injectableContainer.forceRegisterValuePublishers()
+        }
+        values[key(T.self)] = injectedValue
+
+        return injectedValue
+    }
+
+    /**
+     Insert the dependency to be injected only if we are in debug mode
+        - Parameters:
+            - value: A function to create the dependency to inject
+            - type: The type of the dependency to inject
+     */
+    @discardableResult
+    public static func insertForDebug<T>(_ value: @autoclosure () -> T, for type: T.Type) -> T? {
+        if isDebugMode {
+            return try? insert(value, for: type.self)
+        }
+
+        return nil
+    }
+
+    /// Register a publisher that is used inside of a publisher of publishers (switchToLastest) in an Injected Object.
+    /// If the publisher already exists then we send the new publisher to the publisher of publishers...
+    fileprivate static func registerEmbeddedPublisher<PT, T>(
+        _ publisher: CurrentValueSubject<PT, Never>,
+        for type: T.Type,
+        propertyName: String
+    ) where PT: Publisher, PT: Identifiable {
+        guard publishers[key(T.self, PT.self, propertyName: propertyName)] == nil else {
+            // swiftlint:disable:next force_cast
+            let currentPublisher = publishers[key(T.self, PT.self, propertyName: propertyName)] as! CurrentValueSubject<PT, Never>
+            let lhs = currentPublisher.value
+            let rhs = publisher.value
+            if lhs.id != rhs.id {
+                currentPublisher.send(publisher.value)
+            }
+            return
+        }
+
+        publishers[key(T.self, PT.self, propertyName: propertyName)] = publisher
+    }
+
+    /// Register any publisher..
+    /// This needs to be registered once only.
+    /// Because the switchToLatest will generate an AnyPublishers we cannot send a new publisher to it...
+    /// The send is done in the EmbeddedPublisher part
+    fileprivate static func registerSwitchToLatest<PT, T>(_ publisher: PT, for type: T.Type, propertyName: String) where PT: AnyIdentifiablePublisherProtocol {
+        guard switchToLatests[key(T.self, PT.self, propertyName: propertyName)] == nil else {
+            return
+        }
+
+        switchToLatests[key(T.self, PT.self, propertyName: propertyName)] = publisher
+    }
+}
+
+/// Property Wrapper for inplace dependency injection
+@propertyWrapper
+public final class Injected<T> {
+    /// Values of the injected property
+    public var wrappedValue: T {
+        // We can force cast here because we have a queue blocking the get until we have an injected value and we do a conformance test at injection.
+        if let value = InjectedValues[T.self] {
+            return value
+        }
+
+        if InjectedValues.isDebugMode {
+            fatalError("Missing injection: \(key(T.self))")
+        }
+
+        var queue = InjectedValues.queues[key(T.self)]
+
+        if queue == nil {
+            queue = InjectionQueue()
+            InjectedValues.queues[key(T.self)] = queue
+            DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+                if InjectedValues[T.self] == nil {
+                    print("Injection thread is stuck with missing injection: \(key(T.self))")
+                }
+            }
+        }
+
+        // swiftlint:disable:next force_unwrapping
+        return queue!.dispatchQueue.sync {
+            // swiftlint:disable:next force_unwrapping
+            InjectedValues[T.self]!
+        }
+    }
+
+    /// Required Init for property wrapper.
+    public init() {}
+}
+
+/// Property Wrapper for publishers used in Injected objects.
+/// This is used to store the Publisher of Publishers
+/// We need to use this to send new publishers that will become the new active publisher in the switchToLastest
+/// This property wrapper allows to retain the publisher subscribers when the parent injected object is replaced.
+@propertyWrapper
+private final class EmbeddedPublisher<PT, T>: Identifiable where PT: PublisherSubjectProtocol {
+
+    private let defaultValue: CurrentValueSubject<PT, Never>
+    private let propertyName: String
+
+    /// Values of the injected publisher
+    public var wrappedValue: CurrentValueSubject<PT, Never> {
+        (InjectedValues.publishers[key(T.self, PT.self, propertyName: propertyName)] as? CurrentValueSubject<PT, Never>) ?? defaultValue
+    }
+
+    /// Required Init for property wrapper.
+    public init(wrappedValue: CurrentValueSubject<PT, Never>, type: T.Type, propertyName: String) where PT.Failure == Never {
+        self.propertyName = propertyName
+        defaultValue = wrappedValue
+
+        InjectedValues.registerEmbeddedPublisher(defaultValue, for: T.self, propertyName: propertyName)
+    }
+}
+
+private protocol PublisherSubjectProtocol: Publisher, Identifiable, AnyObject { }
+
+private final class ValuePublisherSubject<Output>: PublisherSubjectProtocol {
+    func receive<S>(subscriber: S) where S: Subscriber, Never == S.Failure, Output == S.Input {
+        currentValueSubject.receive(subscriber: subscriber)
+    }
+
+    typealias Failure = Never
+
+    private let currentValueSubject: CurrentValueSubject<Output, Never>
+    private let anyPublisher: AnyPublisher<Output, Never>
+
+    let id = UUID()
+
+    init(_ value: Output) {
+        currentValueSubject = CurrentValueSubject(value)
+        anyPublisher = currentValueSubject.eraseToAnyPublisher()
+    }
+
+    func send(_ value: Output) {
+        currentValueSubject.send(value)
+    }
+
+    var value: Output {
+        currentValueSubject.value
+    }
+
+    var asAnyIdentifiablePublisher: AnyIdentifiablePublisher<AnyPublisher<Output, Never>> {
+        AnyIdentifiablePublisher(anyPublisher)
+    }
+}
+
+private final class OptionalValuePublisherSubject<Output: ExpressibleByNilLiteral>: PublisherSubjectProtocol {
+    func receive<S>(subscriber: S) where S: Subscriber, Never == S.Failure, Output == S.Input {
+        currentValueSubject.receive(subscriber: subscriber)
+    }
+
+    typealias Failure = Never
+
+    private let currentValueSubject: CurrentValueSubject<Output, Never>
+    private let anyPublisher: AnyPublisher<Output, Never>
+
+    let id = UUID()
+
+    init(_ value: Output) {
+        currentValueSubject = CurrentValueSubject(value)
+        anyPublisher = currentValueSubject.eraseToAnyPublisher()
+    }
+
+    func send(_ value: Output) {
+        currentValueSubject.send(value)
+    }
+
+    var value: Output {
+        currentValueSubject.value
+    }
+
+    var asAnyIdentifiablePublisher: AnyIdentifiablePublisher<AnyPublisher<Output, Never>> {
+        AnyIdentifiablePublisher(anyPublisher)
+    }
+}
+
+private final class PassThroughPublisherSubject<Output>: PublisherSubjectProtocol {
+    func receive<S>(subscriber: S) where S: Subscriber, Never == S.Failure, Output == S.Input {
+        passthroughSubject.receive(subscriber: subscriber)
+    }
+
+    typealias Failure = Never
+
+    private let passthroughSubject = PassthroughSubject<Output, Never>()
+    private lazy var anyPublisher: AnyPublisher<Output, Never> = passthroughSubject.eraseToAnyPublisher()
+
+    let id = UUID()
+
+    init() { }
+
+    func send(_ value: Output) {
+        passthroughSubject.send(value)
+    }
+
+    var asAnyIdentifiablePublisher: AnyIdentifiablePublisher<AnyPublisher<Output, Never>> {
+        AnyIdentifiablePublisher(anyPublisher)
+    }
+}
+
+protocol RegistrablePublisherProtocol {
+    func registerPublisherAndSwitchToLatest(propertyName: String)
+}
+
+/// Property Wrapper for publishers used in Injected objects.
+/// This is used for Values like String, Int, Bool...
+/// ONLY FOR USE ON CLASS PROPERTIES
+/// This property wrapper allows to retain the publisher subscribers when the parent injected object is replaced.
+@propertyWrapper
+public final class ValuePublisher<Value, T>: Identifiable, RegistrablePublisherProtocol {
+
+    private var initialValue: Value?
+
+    // swiftlint:disable:next force_unwrapping
+    private lazy var publisher = ValuePublisherSubject<Value>(initialValue!)
+    private var propertyName: String! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    /** THIS PUBLISHER IS ONLY TO BE USED INSIDE OF A CONTAINER OBJECT
+     An InjectableContainer contains ValuePublishers and PassThroughPublishers
+     Inside the Container class, say:
+
+     class CgmSystemService: InjectableContainer, CgmSystemServiceProtocol
+
+     we have:
+
+     @ValuePublisher<Bool, CgmSystemServiceProtocol> var newEGVsAvailable: Bool
+     var newEGVsAvailablePublisher: NewEGVsAvailablePublisher {
+         $newEGVsAvailable
+     }
+
+     @ValuePublisher<[CgmSystemParticipant], CgmSystemServiceProtocol> var systemParticipants: [CgmSystemParticipant]
+     var systemParticipantsPublisher: CgmSystemParticipantsPublisher {
+         $systemParticipants
+     }
+
+     @ValuePublisher<CompositeStateEnvelope, CgmSystemServiceProtocol> var compositeState: CompositeStateEnvelope
+     var compositeStatePublisher: CompositeStatePublisher {
+         $compositeState
+     }
+
+     If anywhere that class we need to subscribe to one of the publishers we CANNOT use $newEGVsAvailable, $systemParticipants, $compositeState
+     These publishers are publishers that are only to be used by client objects. Subscribing to them will retain the subscription even if the in jected parent object is replaced.
+
+     Really inside the container object itself CgmSystemService we want to subscribe to publisher from the currently instantiated object, not to another instanciated object.
+     To achieve that we have to us the internalPublisher AKA internal to the Container object.
+
+     let css1 = CgmSystemService()
+     let css2 = CgmSystemService()
+
+     inside of css1 if we subscribe to newEGVsAvailablePublisher AKA $newEGVsAvailable, then publishing to css2.newEGVsAvailable will result in having
+     css1 sink to receive the value sent to css2. We don't want that.
+
+     When we use instead _newEGVsAvailable.internalPublisher inside of the code of CgmSystemService then publishing to css2.newEGVsAvailable will not trigger the sink in css1
+    **/
+    public var internalPublisher: AnyPublisher<Value, Never> {
+        publisher.asAnyIdentifiablePublisher.eraseToAnyPublisher()
+    }
+
+    func registerPublisherAndSwitchToLatest(propertyName: String) {
+        self.propertyName = propertyName
+        @EmbeddedPublisher(type: T.self, propertyName: propertyName) var anyPublisher = CurrentValueSubject(publisher)
+        InjectedValues.registerSwitchToLatest(
+            AnyIdentifiablePublisher(anyPublisher
+                .switchToLatest()
+                .eraseToAnyPublisher()),
+            for: T.self,
+            propertyName: propertyName)
+    }
+
+    private var anyPublisher: AnyPublisher<Value, Never> {
+        // A crash here indicated your container class is not descending from InjectableContainer or it's not declared as `final`
+        (InjectedValues.switchToLatests[
+            key(T.self, AnyIdentifiablePublisher<AnyPublisher<Value, Never>>.self, propertyName: propertyName)
+            // swiftlint:disable:next force_cast
+        ] as! AnyIdentifiablePublisher<AnyPublisher<Value, Never>>).eraseToAnyPublisher()
+    }
+
+    /// Published Value
+    @available(*, unavailable, message: "@ValuePublisher is only available on properties of classes")
+    public var wrappedValue: Value {
+        get {
+            publisher.value
+        }
+        set {
+            if initialValue == nil {
+                initialValue = newValue
+            }
+
+            publisher.send(newValue)
+        }
+    }
+
+    /// Subscript to allow classes to access the wrappedValue
+    public static subscript<EnclosingContainer: InjectableContainer>(
+        _enclosingInstance object: EnclosingContainer,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingContainer, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingContainer, ValuePublisher<Value, T>>
+    ) -> Value {
+        get {
+            object[keyPath: storageKeyPath].publisher.value
+        }
+        set {
+            let object = object[keyPath: storageKeyPath]
+
+            if object.initialValue == nil {
+                object.initialValue = newValue
+            }
+
+            object.publisher.send(newValue)
+        }
+    }
+
+    /// Initializes the ValuePublisher
+    public init() { }
+
+    /// Initializes the ValuePublisher when using @ValuePublisher and setting a default value.
+    public init(_ wrappedValue: Value) {
+        self.initialValue = wrappedValue
+    }
+
+    /// Return the actual publisher to allow us to send values to the publisher and also subscribe to it using $xxx
+    public var projectedValue: AnyPublisher<Value, Never> {
+        anyPublisher
+    }
+}
+
+/// Property Wrapper for publishers used in Injected objects.
+/// This is used for Values like String, Int, Bool...
+/// ONLY FOR USE ON CLASS PROPERTIES
+/// This property wrapper allows to retain the publisher subscribers when the parent injected object is replaced.
+@propertyWrapper
+public final class OptionalValuePublisher<Value: ExpressibleByNilLiteral, T>: Identifiable, RegistrablePublisherProtocol {
+
+    private var initialValue: Value = nil
+
+    private lazy var publisher = OptionalValuePublisherSubject<Value>(initialValue)
+    private var propertyName: String! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    /** THIS PUBLISHER IS ONLY TO BE USED INSIDE OF A CONTAINER OBJECT
+     An InjectableContainer contains ValuePublishers and PassThroughPublishers
+     Inside the Container class, say:
+
+     class CgmSystemService: InjectableContainer, CgmSystemServiceProtocol
+
+     we have:
+
+     @ValuePublisher<Bool, CgmSystemServiceProtocol> var newEGVsAvailable: Bool
+     var newEGVsAvailablePublisher: NewEGVsAvailablePublisher {
+         $newEGVsAvailable
+     }
+
+     @ValuePublisher<[CgmSystemParticipant], CgmSystemServiceProtocol> var systemParticipants: [CgmSystemParticipant]
+     var systemParticipantsPublisher: CgmSystemParticipantsPublisher {
+         $systemParticipants
+     }
+
+     @ValuePublisher<CompositeStateEnvelope, CgmSystemServiceProtocol> var compositeState: CompositeStateEnvelope
+     var compositeStatePublisher: CompositeStatePublisher {
+         $compositeState
+     }
+
+     If anywhere that class we need to subscribe to one of the publishers we CANNOT use $newEGVsAvailable, $systemParticipants, $compositeState
+     These publishers are publishers that are only to be used by client objects. Subscribing to them will retain the subscription even if the in jected parent object is replaced.
+
+     Really inside the container object itself CgmSystemService we want to subscribe to publisher from the currently instantiated object, not to another instanciated object.
+     To achieve that we have to us the internalPublisher AKA internal to the Container object.
+
+     let css1 = CgmSystemService()
+     let css2 = CgmSystemService()
+
+     inside of css1 if we subscribe to newEGVsAvailablePublisher AKA $newEGVsAvailable, then publishing to css2.newEGVsAvailable will result in having
+     css1 sink to receive the value sent to css2. We don't want that.
+
+     When we use instead _newEGVsAvailable.internalPublisher inside of the code of CgmSystemService then publishing to css2.newEGVsAvailable will not trigger the sink in css1
+    **/
+    public var internalPublisher: AnyPublisher<Value, Never> {
+        publisher.asAnyIdentifiablePublisher.eraseToAnyPublisher()
+    }
+
+    func registerPublisherAndSwitchToLatest(propertyName: String) {
+        self.propertyName = propertyName
+        @EmbeddedPublisher(type: T.self, propertyName: propertyName) var anyPublisher = CurrentValueSubject(publisher)
+        InjectedValues.registerSwitchToLatest(
+            AnyIdentifiablePublisher(anyPublisher
+                .switchToLatest()
+                .eraseToAnyPublisher()),
+            for: T.self,
+            propertyName: propertyName)
+    }
+
+    private var anyPublisher: AnyPublisher<Value, Never> {
+        // A crash here indicated your container class is not descending from InjectableContainer or it's not declared as `final`
+        (InjectedValues.switchToLatests[
+            key(T.self, AnyIdentifiablePublisher<AnyPublisher<Value, Never>>.self, propertyName: propertyName)
+            // swiftlint:disable:next force_cast
+        ] as! AnyIdentifiablePublisher<AnyPublisher<Value, Never>>).eraseToAnyPublisher()
+    }
+
+    /// Published Value
+    @available(*, unavailable, message: "@ValuePublisher is only available on properties of classes")
+    public var wrappedValue: Value {
+        get {
+            publisher.value
+        }
+        set {
+            // InitialValue can be nil and is defaulted to that. Value is of type ExpressibleByNilLiteral and can indeed be nil
+            if initialValue == nil {
+                initialValue = newValue
+            }
+
+            publisher.send(newValue)
+        }
+    }
+
+    /// Subscript to allow classes to access the wrappedValue
+    public static subscript<EnclosingContainer: InjectableContainer>(
+        _enclosingInstance object: EnclosingContainer,
+        wrapped wrappedKeyPath: ReferenceWritableKeyPath<EnclosingContainer, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingContainer, OptionalValuePublisher<Value, T>>
+    ) -> Value {
+        get {
+            object[keyPath: storageKeyPath].publisher.value
+        }
+        set {
+            let object = object[keyPath: storageKeyPath]
+
+            // InitialValue can be nil and is defaulted to that. Value is of type ExpressibleByNilLiteral and can indeed be nil
+            if object.initialValue == nil {
+                object.initialValue = newValue
+            }
+
+            object.publisher.send(newValue)
+        }
+    }
+
+    /// Initializes the ValuePublisher
+    public init() { }
+
+    /// Initializes the ValuePublisher when using @ValuePublisher and setting a default value.
+    public init(_ wrappedValue: Value) {
+        self.initialValue = wrappedValue
+    }
+
+    /// Return the actual publisher to allow us to send values to the publisher and also subscribe to it using $xxx
+    public var projectedValue: AnyPublisher<Value, Never> {
+        anyPublisher
+    }
+}
+
+/// Property Wrapper for publishers used in Injected objects.
+/// ONLY FOR USE ON CLASS PROPERTIES
+/// This property wrapper allows to retain the publisher subscribers when the parent injected object is replaced.
+@propertyWrapper
+public final class PassThroughPublisher<Value, T>: Identifiable, RegistrablePublisherProtocol {
+    private lazy var publisher = PassThroughPublisherSubject<Value>()
+    private var propertyName: String! // swiftlint:disable:this implicitly_unwrapped_optional
+
+    /// THIS PUBLISHER IS ONLY TO BE USED INSIDE OF THE INIT OF THE CONTAINER OBJECT
+    /// IT WILL NOT PERSIST INJECTION.
+    public var internalPublisher: AnyPublisher<Value, Never> {
+        publisher.asAnyIdentifiablePublisher.eraseToAnyPublisher()
+    }
+
+    func registerPublisherAndSwitchToLatest(propertyName: String) {
+        self.propertyName = propertyName
+        @EmbeddedPublisher(type: T.self, propertyName: propertyName) var anyPublisher = CurrentValueSubject(publisher)
+        InjectedValues.registerSwitchToLatest(
+            AnyIdentifiablePublisher(anyPublisher
+                .switchToLatest()
+                .eraseToAnyPublisher()),
+            for: T.self,
+            propertyName: propertyName)
+    }
+
+    private var anyPublisher: AnyPublisher<Value, Never> {
+        // A crash here indicated your container class is not descending from InjectableContainer
+        (InjectedValues.switchToLatests[
+            key(T.self, AnyIdentifiablePublisher<AnyPublisher<Value, Never>>.self, propertyName: propertyName)
+            // swiftlint:disable:next force_cast
+        ] as! AnyIdentifiablePublisher<AnyPublisher<Value, Never>>).eraseToAnyPublisher()
+    }
+
+    /// Published Value
+    @available(*, unavailable, message: "@PassThroughPublisher is only available on properties of classes")
+    public var wrappedValue: PassThroughPublisher<Value, T> {
+        self
+    }
+
+    /// Subscript to allow classes to access the wrappedValue
+    public static subscript<EnclosingContainer: InjectableContainer>(
+        _enclosingInstance object: EnclosingContainer,
+        wrapped wrappedKeyPath: KeyPath<EnclosingContainer, PassThroughPublisher<Value, T>>,
+        storage storageKeyPath: KeyPath<EnclosingContainer, PassThroughPublisher<Value, T>>
+    ) -> PassThroughPublisher<Value, T> {
+        object[keyPath: storageKeyPath]
+    }
+
+    /// Publishes a new value
+    public func send(_ value: Value) {
+        publisher.send(value)
+    }
+
+    /// Initializes the ValuePublisher
+    public init() { }
+
+    /// Return the actual publisher to allow us to send values to the publisher and also subscribe to it using $xxx
+    public var projectedValue: AnyPublisher<Value, Never> {
+        anyPublisher
+    }
+}
+
+private protocol AnyIdentifiablePublisherProtocol: Publisher, Identifiable, Equatable {}
+
+/// Class to make any Publisher Identifiable.
+public final class AnyIdentifiablePublisher<P: Publisher>: AnyIdentifiablePublisherProtocol {
+    /// The Output type of the original publisher
+    public typealias Output = P.Output
+    /// The Failure type of the original publisher
+    public typealias Failure = P.Failure
+
+    /// Identifier of the publisher
+    public var id = UUID()
+
+    /// Conformance to equatable
+    public static func == (lhs: AnyIdentifiablePublisher<P>, rhs: AnyIdentifiablePublisher<P>) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    /// Attaches the specified subscriber to this publisher.
+    /// - Parameter subscriber: The subscriber to attach to this Publisher, after which it can receive values.
+    public func receive<S>(subscriber: S) where S: Subscriber, P.Failure == S.Failure, P.Output == S.Input {
+        publisher.receive(subscriber: subscriber)
+    }
+
+    /// The original publisher
+    public let publisher: P
+
+    /// Initializes the AnyIdentifiablePublisher by passing the original publisher as a parameter.
+    public init(_ value: P) {
+        self.publisher = value
+    }
+
+    /// Erase to any publisher to original publisher.
+    public func eraseToAnyPublisher() -> AnyPublisher<Output, Failure> {
+        guard let publisher = publisher as? AnyPublisher<Output, Failure> else {
+            return publisher.eraseToAnyPublisher()
+        }
+
+        return publisher
+    }
+}
+
+///  Property wrapper for injected object that are optional.
+///  This is useful for things like GCS, Share,... since some clients might not want to use them.
+@propertyWrapper
+public final class InjectedOrNil<T> where T: ExpressibleByNilLiteral {
+
+    var defaultValue: T = nil
+
+    /// Published Value
+    public var wrappedValue: T {
+        InjectedValues[T.self] ?? defaultValue
+    }
+
+    /// Required Init for property wrapper.
+    public init() {}
+}

--- a/TradingAlarm/Sections - ViewControllers/Alert Settings/AlarmSettingsViewModel.swift
+++ b/TradingAlarm/Sections - ViewControllers/Alert Settings/AlarmSettingsViewModel.swift
@@ -8,5 +8,8 @@
 import Foundation
 
 class AlarmSettingsViewModel {
-    var alarmsList: [Alarm] = DataManager.shared.allAlarms
+    @Injected var dataManager: DataManager
+    
+    lazy var alarmsList: [Alarm] = dataManager.allAlarms
+    
 }

--- a/TradingAlarm/Sections - ViewControllers/Alerting Page/AlarmsViewController.swift
+++ b/TradingAlarm/Sections - ViewControllers/Alerting Page/AlarmsViewController.swift
@@ -16,17 +16,20 @@ class AlarmsViewController: UIViewController {
     var subscribers = [AnyCancellable]()
     let soundPlayer = SoundPlayer()
     
+    @Injected var dataManager: DataManager
+    @Injected var alarmScheduler: AlarmScheduler
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         // Listens for triggered alarms to display alarm screen
-        DataManager.shared.alarmScheduler.triggeredAlertPublisher
+        alarmScheduler.alarmResponder.triggeredAlertPublisher
             .receive(on: DispatchQueue.main)
             .sink { alarmingState in
                 let identifier = alarmingState.id
                 
                 print("Received AlertId: \(identifier)for displaying")
-                guard let activeAlert = DataManager.shared.getAlertBy(id: identifier) else {
+                guard let activeAlert = self.dataManager.getAlertBy(id: identifier) else {
                     return
                 }
                 

--- a/TradingAlarm/SupportingFiles/AppDelegate.swift
+++ b/TradingAlarm/SupportingFiles/AppDelegate.swift
@@ -7,12 +7,18 @@
 
 import UIKit
 import UserNotifications
+
 @main
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    let appServices = AppServices()
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        UNUserNotificationCenter.current().delegate = DataManager.shared.alarmScheduler
+        @Injected var scheduler: AlarmScheduler
+        
+        UNUserNotificationCenter.current().delegate = scheduler.alarmResponder
         
         UNUserNotificationCenter.current().requestAuthorization(options: [.sound,.alert,.badge, .criticalAlert]) { (granted, error) in
             if granted {
@@ -69,13 +75,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UserDefaults.standard.synchronize()
     }
 }
-
-//extension AppDelegate: UNUserNotificationCenterDelegate {
-//    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
-//        print("userNotificationCenter didReceive")
-//    }
-//    
-//    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-//        print("userNotificationCenter willPresent")
-//    }
-//}


### PR DESCRIPTION
# Summary
AlarmScheduler - AlarmResponder - LifecycleManager

-Injecting AlarmScheduler - LifecycleManager in AppServices

-Refactoring for separation of concerns
— AppServices handle the retention and inject of need app classes and handles Lifecycle events
— DataManager handles holding a models needed. for Alarm management
— AlarmScheduler is responsible for converting, scheduling, and post alarms to the notificationCenter
— AlarmResponder respond to Lifecycle events and publishes Alarm was triggered (ready for display)